### PR TITLE
feat: version without OpenMP enabled to allow top-level MP delegation

### DIFF
--- a/dqclibs/libs/CMakeLists.txt
+++ b/dqclibs/libs/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 
 find_package(OpenMP)
 if(OPENMP_FOUND)
-  set(HAVE_OPENMP 1)
+  set(OpenMP_C_FLAGS " ")
 else ()
   set(OpenMP_C_FLAGS " ")
 endif()

--- a/dqclibs/libs/CMakeLists.txt
+++ b/dqclibs/libs/CMakeLists.txt
@@ -38,6 +38,8 @@ endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+option(USE_OPENMP "Use OpenMP for library compilation" OFF)
+
 # Architecture specified cmake flags.  See also the templates in
 # pyscf/lib/cmake_arch_config
 if(EXISTS "${PROJECT_SOURCE_DIR}/cmake.arch.inc")
@@ -57,7 +59,12 @@ endif()
 
 find_package(OpenMP)
 if(OPENMP_FOUND)
-  set(OpenMP_C_FLAGS " ")
+  if(USE_OPENMP)
+    set(HAVE_OPENMP 1)
+  else ()
+    set(OpenMP_C_FLAGS " ")
+  endif()
+  message(STATUS "Using OpenMP ${USE_OPENMP}")
 else ()
   set(OpenMP_C_FLAGS " ")
 endif()

--- a/dqclibs/libs/modifications.txt
+++ b/dqclibs/libs/modifications.txt
@@ -3,5 +3,5 @@ This lib directory contains libraries from PySCF. The modifications made:
 * In the code generator, added:
   * Higher derivatives for nabla (nabla^2, nabla^3)
   * Laplacian (nabla dot nabla) and the derivatives of it
-* Modified CMakeLists.txt to always set (OpenMP_C_FLAGS " "), to avoid MP clashes
-  * Previous value was setting (HAVE_OPENMP 1) if OPENMP_FOUND
+* Modified CMakeLists.txt to have (OpenMP_C_FLAGS " ") if not setting option USE_OPENMP to ON
+  * Turn on OpenMP with -DUSE_OPENMP=ON

--- a/dqclibs/libs/modifications.txt
+++ b/dqclibs/libs/modifications.txt
@@ -3,3 +3,5 @@ This lib directory contains libraries from PySCF. The modifications made:
 * In the code generator, added:
   * Higher derivatives for nabla (nabla^2, nabla^3)
   * Laplacian (nabla dot nabla) and the derivatives of it
+* Modified CMakeLists.txt to always set (OpenMP_C_FLAGS " "), to avoid MP clashes
+  * Previous value was setting (HAVE_OPENMP 1) if OPENMP_FOUND


### PR DESCRIPTION
- Previous version used OpenMP, suspected cause of clashes with top-level MP attempts
- Deactivating OpenMP in compilation will cause it to build fine, but not use any MP
- Local build and test ran okay